### PR TITLE
converted the code to be grid-size agnostic

### DIFF
--- a/Awesome.m
+++ b/Awesome.m
@@ -7,11 +7,15 @@ addpath srcsnk
 load data/ao
 load data/water_transport
 
+ao.nlat = length(ao.lat)
+ao.nlon = length(ao.lon)
+ao.ndepth = length(ao.depth)
+
 % initailize the b array with zeros
-b = zeros(200160,1);
+b = zeros(ao.nocn,1);
 
 % initalize the A array with zeros
-A = sparse(200160,200160);
+A = sparse(ao.nocn,ao.nocn);
 
 % modify the A and b matrices to represent biogeochemical cycling; this
 % searches for do.function.on equal to 1, where the function is any of the
@@ -45,7 +49,7 @@ tic
 e=A\b; % these six characters perform the magic of linear algebra!
 toc
 
-% linear algebra solution yields an array of the 200160 values of elemental
+% linear algebra solution yields an array of the nocn=200160 values of elemental
 % concentrations (e), which we then need to put into a shoebox (put them
 % into the 3d model grid E)
 E = ao.nanOCN;

--- a/Awesome.m
+++ b/Awesome.m
@@ -7,10 +7,6 @@ addpath srcsnk
 load data/ao
 load data/water_transport
 
-ao.nlat = length(ao.lat)
-ao.nlon = length(ao.lon)
-ao.ndepth = length(ao.depth)
-
 % initailize the b array with zeros
 b = zeros(ao.nocn,1);
 

--- a/GUI/GUI_AO.m
+++ b/GUI/GUI_AO.m
@@ -695,7 +695,7 @@ if get(handles.radiobutton12,'value')
     depthAT=str2double(get(handles.edit33,'String'));
     ALLtop=ao.depth-ao.height/2;
     ALLbtm=ao.depth+ao.height/2;
-    for i=1:ao.ndepth
+    for i=1:length(ao.depth)
         if depthAT>=ALLtop(i) && depthAT<ALLbtm(i)
             layer=i;
         end

--- a/GUI/GUI_AO.m
+++ b/GUI/GUI_AO.m
@@ -695,7 +695,7 @@ if get(handles.radiobutton12,'value')
     depthAT=str2double(get(handles.edit33,'String'));
     ALLtop=ao.depth-ao.height/2;
     ALLbtm=ao.depth+ao.height/2;
-    for i=1:24
+    for i=1:ao.ndepth
         if depthAT>=ALLtop(i) && depthAT<ALLbtm(i)
             layer=i;
         end

--- a/srcsnk/bioalpha.m
+++ b/srcsnk/bioalpha.m
@@ -43,7 +43,7 @@ zc = BOXTOP(1,1,3);
 % tops and bottoms of each box (note that this matrix is nlat x nlon x (ndepth+1) because
 % it contains the depth at the top of the top box and at the bottom of the
 % bottom box)
-INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,ao.ndepth));
+INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,length(ao.depth)));
 
 % calculate the particle concentration profile as the fraction remaining
 % compared to zc; this is the particle concentration at the interfaces
@@ -75,12 +75,12 @@ PFD = PFD.*ao.OCN;
 % remineralization at every depth within that grid-column will be related
 % to the productivity which occurred in the top grid cell (1,1,1), and
 % seprarately to the productivity which occurred in grid cell (1,1,2)
-KPROD1 = repmat(KPROD(:,:,1),1,1,ao.ndepth); KPROD2 = repmat(KPROD(:,:,2),1,1,ao.ndepth);
+KPROD1 = repmat(KPROD(:,:,1),1,1,length(ao.depth)); KPROD2 = repmat(KPROD(:,:,2),1,1,length(ao.depth));
 
 % similarly, the equation position (column in the A matrix) for every grid
 % cell in the water column (1,1,:) will depend on the equation position of
 % the top grid cell (1,1,1) from which particles originate
-FROM1 = repmat(ao.EQNPOS(:,:,1),1,1,ao.ndepth); FROM2 = repmat(ao.EQNPOS(:,:,2),1,1,ao.ndepth);
+FROM1 = repmat(ao.EQNPOS(:,:,1),1,1,length(ao.depth)); FROM2 = repmat(ao.EQNPOS(:,:,2),1,1,length(ao.depth));
 from1 = FROM1(ao.iocn); from2 = FROM2(ao.iocn);
 
 % the equation position (row in the A matrix) in which we slot the

--- a/srcsnk/bioalpha.m
+++ b/srcsnk/bioalpha.m
@@ -40,14 +40,14 @@ BOXBOTTOM = ao.DEPTH+ao.HEIGHT/2;
 zc = BOXTOP(1,1,3);
 
 % make a new 'interface depth' shoebox which contains the depths at the
-% tops and bottoms of each box (note that this matrix is 91x180x25 because
+% tops and bottoms of each box (note that this matrix is nlat x nlon x (ndepth+1) because
 % it contains the depth at the top of the top box and at the bottom of the
 % bottom box)
-INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,24));
+INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,ao.ndepth));
 
 % calculate the particle concentration profile as the fraction remaining
 % compared to zc; this is the particle concentration at the interfaces
-% between boxes so this matrix is also 91x180x25
+% between boxes so this matrix is also nlat x nlon x (ndepth+1)
 PARTICLES = (INTDEPTH./zc).^-martinb;
 
 % calculate the particle flux divergence (PFD), which is the difference
@@ -75,12 +75,12 @@ PFD = PFD.*ao.OCN;
 % remineralization at every depth within that grid-column will be related
 % to the productivity which occurred in the top grid cell (1,1,1), and
 % seprarately to the productivity which occurred in grid cell (1,1,2)
-KPROD1 = repmat(KPROD(:,:,1),1,1,24); KPROD2 = repmat(KPROD(:,:,2),1,1,24);
+KPROD1 = repmat(KPROD(:,:,1),1,1,ao.ndepth); KPROD2 = repmat(KPROD(:,:,2),1,1,ao.ndepth);
 
 % similarly, the equation position (column in the A matrix) for every grid
 % cell in the water column (1,1,:) will depend on the equation position of
 % the top grid cell (1,1,1) from which particles originate
-FROM1 = repmat(ao.EQNPOS(:,:,1),1,1,24); FROM2 = repmat(ao.EQNPOS(:,:,2),1,1,24);
+FROM1 = repmat(ao.EQNPOS(:,:,1),1,1,ao.ndepth); FROM2 = repmat(ao.EQNPOS(:,:,2),1,1,ao.ndepth);
 from1 = FROM1(ao.iocn); from2 = FROM2(ao.iocn);
 
 % the equation position (row in the A matrix) in which we slot the

--- a/srcsnk/bioredfield.m
+++ b/srcsnk/bioredfield.m
@@ -37,14 +37,14 @@ BOXBOTTOM = ao.DEPTH+ao.HEIGHT/2;
 zc = BOXTOP(1,1,3);
 
 % make a new 'interface depth' shoebox which contains the depths at the
-% tops and bottoms of each box (note that this matrix is 91x180x25 because
+% tops and bottoms of each box (note that this matrix is nlat x nlon x (ndepth+1) because
 % it contains the depth at the top of the top box and at the bottom of the
 % bottom box)
-INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,24));
+INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,ao.ndepth));
 
 % calculate the particle concentration profile as the fraction remaining
 % compared to zc; this is the particle concentration at the interfaces
-% between between boxes so this matrix is also 91x180x25
+% between between boxes so this matrix is also nlat x nlon x (ndepth+1)
 PARTICLES = (INTDEPTH./zc).^-martinb;
 
 % calculate the particle flux divergence (PFD), which is the difference
@@ -71,7 +71,7 @@ PFD = PFD.*ao.OCN;
 % remineralization which occurs in grid-column (1,1,:), the
 % remineralization at every depth within that grid-column will be related
 % to the productivity which occurred in the top grid cell (1,1,1)
-EPROD1 = repmat(EPROD(:,:,1),1,1,24); EPROD2 = repmat(EPROD(:,:,2),1,1,24);
+EPROD1 = repmat(EPROD(:,:,1),1,1,ao.ndepth); EPROD2 = repmat(EPROD(:,:,2),1,1,ao.ndepth);
 
 % the magnitude of the remineralization is the surface productivity,
 % multiplied by the PFD (fraction of that productivity with remineralizes),

--- a/srcsnk/bioredfield.m
+++ b/srcsnk/bioredfield.m
@@ -40,7 +40,7 @@ zc = BOXTOP(1,1,3);
 % tops and bottoms of each box (note that this matrix is nlat x nlon x (ndepth+1) because
 % it contains the depth at the top of the top box and at the bottom of the
 % bottom box)
-INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,ao.ndepth));
+INTDEPTH = cat(3,BOXTOP,BOXBOTTOM(:,:,length(ao.depth)));
 
 % calculate the particle concentration profile as the fraction remaining
 % compared to zc; this is the particle concentration at the interfaces
@@ -71,7 +71,7 @@ PFD = PFD.*ao.OCN;
 % remineralization which occurs in grid-column (1,1,:), the
 % remineralization at every depth within that grid-column will be related
 % to the productivity which occurred in the top grid cell (1,1,1)
-EPROD1 = repmat(EPROD(:,:,1),1,1,ao.ndepth); EPROD2 = repmat(EPROD(:,:,2),1,1,ao.ndepth);
+EPROD1 = repmat(EPROD(:,:,1),1,1,length(ao.depth)); EPROD2 = repmat(EPROD(:,:,2),1,1,length(ao.depth));
 
 % the magnitude of the remineralization is the surface productivity,
 % multiplied by the PFD (fraction of that productivity with remineralizes),

--- a/srcsnk/conc.m
+++ b/srcsnk/conc.m
@@ -37,12 +37,12 @@ taug = 1e6;
 
 % calculate the input of your element to every box at a rate set by the
 % concentration divided by a million years
-inputb = ones(200160,1)*c/taug;
+inputb = ones(size(b))*c/taug;
 
     
 % calculate the loss of your element from each box with a decay timescale of a
 % million years
-lossA = speye(200160,200160)/taug;
+lossA = speye(size(A))/taug;
 
 % modify the A abd b matrices
 b = b - inputb;

--- a/srcsnk/revscav.m
+++ b/srcsnk/revscav.m
@@ -37,7 +37,7 @@ sinkout = K*w./ao.Height;
 
 % find the equation position (positions in the A matrix) of the grid cells
 % which lie below each cell
-EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:ao.ndepth),zeros(ao.nlat,ao.nlon,1));
+EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:length(ao.depth)),zeros(length(ao.lat),length(ao.lon),1));
 
 % define the equation positions that particles are sinking from, as well as
 % the volumes and heights of those grid cells

--- a/srcsnk/revscav.m
+++ b/srcsnk/revscav.m
@@ -37,7 +37,7 @@ sinkout = K*w./ao.Height;
 
 % find the equation position (positions in the A matrix) of the grid cells
 % which lie below each cell
-EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:24),zeros(91,180,1));
+EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:ao.ndepth),zeros(ao.nlat,ao.nlon,1));
 
 % define the equation positions that particles are sinking from, as well as
 % the volumes and heights of those grid cells

--- a/srcsnk/revscavPOC.m
+++ b/srcsnk/revscavPOC.m
@@ -37,7 +37,7 @@ sinkout = K*POC.*(w./ao.Height);
 
 % find the equation position (positions in the A matrix) of the grid cells
 % which lie below each cell
-EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:ao.ndepth),zeros(ao.nlat,ao.nlon,1));
+EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:length(ao.depth)),zeros(length(ao.lat),length(ao.lon),1));
 
 % define the equation positions that particles are sinking from, as well as
 % the volumes and heights of those grid cells

--- a/srcsnk/revscavPOC.m
+++ b/srcsnk/revscavPOC.m
@@ -37,7 +37,7 @@ sinkout = K*POC.*(w./ao.Height);
 
 % find the equation position (positions in the A matrix) of the grid cells
 % which lie below each cell
-EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:24),zeros(91,180,1));
+EQNPOSBELOW = cat(3,ao.EQNPOS(:,:,2:ao.ndepth),zeros(ao.nlat,ao.nlon,1));
 
 % define the equation positions that particles are sinking from, as well as
 % the volumes and heights of those grid cells


### PR DESCRIPTION
I basically removed the dependency of the code on the size of the grid. This was done by calling `length` or `size` on the fields `lat`, `lon`, `depth`, which were available in `ao`. Also use the sizes of `A` and `b`. All this avoids having the values `91`, `180`, `24`, and `200180` in the code, and should make the AWESOMEOCIM code work on different grids. 

Please try out this code before merging as I have not tested it myself.